### PR TITLE
Ktep/toomre potential

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OrbitalElements"
 uuid = "a3b07092-bde3-4843-b84f-c597d614ec7b"
-version = "2.0.0dev-5"
+version = "2.1.0"
 
 [deps]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/src/OrbitalElements.jl
+++ b/src/OrbitalElements.jl
@@ -19,6 +19,7 @@ export IsochronePotential, AnalyticIsochrone, NumericalIsochrone
 export PlummerPotential, NumericalPlummer, SemiAnalyticPlummer
 export HernquistPotential, NumericalHernquist
 export MestelPotential, TaperedMestel
+export ToomrePotential, AnalyticToomre
 export KuzminKutuzovPotential, AnalyticKuzminKutuzov
 # potential functions
 export ψ, dψ, d2ψ

--- a/src/OrbitalElements.jl
+++ b/src/OrbitalElements.jl
@@ -19,7 +19,7 @@ export IsochronePotential, AnalyticIsochrone, NumericalIsochrone
 export PlummerPotential, NumericalPlummer, SemiAnalyticPlummer
 export HernquistPotential, NumericalHernquist
 export MestelPotential, TaperedMestel
-export ToomrePotential, AnalyticToomre
+export ToomrePotential
 export KuzminKutuzovPotential, AnalyticKuzminKutuzov
 # potential functions
 export ψ, dψ, d2ψ

--- a/src/OrbitalElements.jl
+++ b/src/OrbitalElements.jl
@@ -19,7 +19,7 @@ export IsochronePotential, AnalyticIsochrone, NumericalIsochrone
 export PlummerPotential, NumericalPlummer, SemiAnalyticPlummer
 export HernquistPotential, NumericalHernquist
 export MestelPotential, TaperedMestel
-export ToomrePotential
+export ToomrePotential, NumericalToomre, SemiAnalyticToomre
 export KuzminKutuzovPotential, AnalyticKuzminKutuzov
 # potential functions
 export ψ, dψ, d2ψ

--- a/src/mappings/actions/twointegral/frequencies/anomaly.jl
+++ b/src/mappings/actions/twointegral/frequencies/anomaly.jl
@@ -56,7 +56,7 @@ _henond4f(x::Float64)::Float64 = 0.
 mapping from anomaly to radius. Default is Henon anomaly.
 
 @IMPROVE: right now, Hénon anomaly is hard-coded. (except for AnalyticIsochrone and 
-SemiAnalyticPlummer, for which it is redefined using specific anomaly)
+SemiAnalyticPlummer and SemiAnalyticToomre, for which it is redefined using specific anomaly)
 """
 function radius_from_anomaly(
     w::Float64,
@@ -74,7 +74,7 @@ end
 derivative of the mapping from anomaly to radius. Default is Henon anomaly.
 
 @IMPROVE: right now, Hénon anomaly is hard-coded. (except for AnalyticIsochrone and 
-SemiAnalyticPlummer, for which it is redefined using specific anomaly)
+SemiAnalyticPlummer and SemiAnalyticToomre, for which it is redefined using specific anomaly)
 """
 function radius_from_anomaly_derivative(
     w::Float64,

--- a/src/mappings/actions/twointegral/frequencies/circular.jl
+++ b/src/mappings/actions/twointegral/frequencies/circular.jl
@@ -19,10 +19,13 @@ function _Ω1circular(
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     if r == 0
-        return 2 * sqrt(abs(d2ψ(r, model)))
+        _d2ψval = d2ψ(r, model)
+        @assert _d2ψval >= -1e-10 "d2ψ unexpectedly negative: $_d2ψval"
+        return 2 * sqrt(max(0.0, _d2ψval))
     end
 
-    return sqrt(abs(d2ψ(r, model) + 3 * dψ(r, model) / r))
+    _dψval = (d2ψ(r, model) + 3 * dψ(r, model) / r)
+    return sqrt(max(0.0, _dψval))
 end
 
 """
@@ -34,10 +37,14 @@ function _Ω2circular(
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     if r == 0
-        return sqrt(abs(d2ψ(r, model)))
+        _d2ψval = d2ψ(r, model)
+        @assert _d2ψval >= -1e-10 "d2ψ unexpectedly negative: $_d2ψval"
+        return sqrt(max(0.0, _d2ψval))
     end
 
-    return sqrt(abs(dψ(r, model) / r))
+    _dψval = dψ(r, model)
+    @assert _dψval >= -1e-10 "dψ unexpectedly negative: $_dψval"
+    return sqrt(max(0.0, _dψval / r))
 end
 
 """

--- a/src/mappings/actions/twointegral/frequencies/circular.jl
+++ b/src/mappings/actions/twointegral/frequencies/circular.jl
@@ -22,7 +22,7 @@ function _Ω1circular(
         return 2 * sqrt(abs(d2ψ(r, model)))
     end
 
-    return sqrt(d2ψ(r, model) + 3 * dψ(r, model) / r)
+    return sqrt(abs(d2ψ(r, model) + 3 * dψ(r, model) / r))
 end
 
 """
@@ -37,7 +37,7 @@ function _Ω2circular(
         return sqrt(abs(d2ψ(r, model)))
     end
 
-    return sqrt(dψ(r, model) / r)
+    return sqrt(abs(dψ(r, model) / r))
 end
 
 """

--- a/src/mappings/actions/twointegral/frequencies/radial_velocity.jl
+++ b/src/mappings/actions/twointegral/frequencies/radial_velocity.jl
@@ -79,7 +79,7 @@ function radial_velocity(
         return 0.0
     end
         
-    return sqrt(vrSQ)
+    return sqrt(abs(vrSQ))
 end
 
 

--- a/src/mappings/analytic.jl
+++ b/src/mappings/analytic.jl
@@ -7,3 +7,6 @@ include("analytic/isochrone.jl")
 
 # Include Plummer analytic mapping methods
 include("analytic/plummer.jl")
+
+# Include Toomre analytic mapping methods
+include("analytic/toomre.jl")

--- a/src/mappings/analytic/anomalies.jl
+++ b/src/mappings/analytic/anomalies.jl
@@ -5,6 +5,9 @@
 #
 ########################################################################
 const AnalyticIsochronePlummer = Union{AnalyticIsochrone, SemiAnalyticPlummer}
+const AnalyticIsochronePlummerToomre = Union{AnalyticIsochrone, SemiAnalyticPlummer, SemiAnalyticToomre}
+const AnalyticPlummerToomre = Union{SemiAnalyticPlummer, SemiAnalyticToomre}
+
 """
     _s_from_r(r, model[, params])
 
@@ -12,7 +15,7 @@ effective radius.
 """
 function _s_from_r(
     r::Float64,
-    model::AnalyticIsochronePlummer,
+    model::AnalyticIsochronePlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )
     x = r / radial_scale(model) # dimensionless radius
@@ -26,7 +29,7 @@ radius as a function of effective radius.
 """
 function _r_from_s(
     s::Float64,
-    model::AnalyticIsochronePlummer,
+    model::AnalyticIsochronePlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )
     # Cure for unexpected effective radius (close to 1, otherwise let the sqrt throw 
@@ -46,7 +49,7 @@ derivative of radius w.r.t. effective radius.
 """
 function _r_from_s_derivative(
     s::Float64,
-    model::AnalyticIsochronePlummer,
+    model::AnalyticIsochronePlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )
     # Cure for unexpected effective radius (close to 1, otherwise let the sqrt throw 
@@ -76,14 +79,14 @@ function _spsa_from_rpra(
 end
 
 """
-    _rpra_from_spsa(sp, sa, model::PlummerPotential)
+    _rpra_from_spsa(sp, sa, model::AnalyticPlummerToomre)
 
 the orbit pericentre `rp` and apocentre `ra` from extremal anomalies.
 """
 function _rpra_from_spsa(
     sp::Float64,
     sa::Float64,
-    model::SemiAnalyticPlummer,
+    model::AnalyticPlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )
     # Broadcast the anomaly over peri and apocenter (allocation-free)
@@ -122,7 +125,7 @@ function radius_from_anomaly(
     w::Float64,
     a::Float64,
     e::Float64,
-    model::AnalyticIsochronePlummer,
+    model::AnalyticIsochronePlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     a_eff, e_eff = _effective_ae_from_ae(a, e, model, params)
@@ -134,7 +137,7 @@ function radius_from_anomaly_derivative(
     w::Float64,
     a::Float64,
     e::Float64,
-    model::AnalyticIsochronePlummer,
+    model::AnalyticIsochronePlummerToomre,
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     a_eff, e_eff = _effective_ae_from_ae(a, e, model, params)

--- a/src/mappings/analytic/anomalies.jl
+++ b/src/mappings/analytic/anomalies.jl
@@ -38,7 +38,7 @@ function _r_from_s(
     if 1 - tol < s < 1
         return 0.0
     end
-    x = sqrt(s^2 - 1) # dimensionless radius
+    x = sqrt(abs(s^2 - 1)) # dimensionless radius
     return radial_scale(model) * x
 end
 
@@ -58,7 +58,7 @@ function _r_from_s_derivative(
     if 1 - tol < s < 1
         return 0.0
     end
-    dxds = s / sqrt(s^2 - 1) # dimensionless radius derivative
+    dxds = s / sqrt(abs(s^2 - 1)) # dimensionless radius derivative
     return radial_scale(model) * dxds
 end
 

--- a/src/mappings/analytic/isochrone.jl
+++ b/src/mappings/analytic/isochrone.jl
@@ -274,7 +274,7 @@ function _EL_from_αβ(
 )
     return (
         energy_scale(model) * α^(2/3) / 2, 
-        momentum_scale(model) * (2β - 1) / (sqrt(β * (1 - β)))
+        momentum_scale(model) * (2β - 1) / (sqrt(abs(β * (1 - β))))
     )
 end
 

--- a/src/mappings/analytic/plummer.jl
+++ b/src/mappings/analytic/plummer.jl
@@ -21,7 +21,7 @@ function EL_from_ae(
     rp, ra = rpra_from_ae(a, e)
     sp, sa = _spsa_from_rpra(rp, ra, model, params) # extremal anomalies on the orbit
     Ẽ = 1 / sp - (sa^2 - 1) / (sa * sp * (sa + sp)) # dimensionless energy
-    L̃ = sqrt(2 * (sp^2 - 1) * (sa^2 - 1) / (sa * sp * (sa + sp))) # dimensionless momentum
+    L̃ = sqrt(abs(2 * (sp^2 - 1) * (sa^2 - 1) / (sa * sp * (sa + sp)))) # dimensionless momentum
     return energy_scale(model) * Ẽ, momentum_scale(model) * L̃ 
 end
 
@@ -192,7 +192,7 @@ function _βcircular(
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     x = r / radial_scale(model) 
-    return sqrt(1 - 3 / (4 + x^2))
+    return sqrt(abs(1 - 3 / (4 + x^2)))
 end
 
 function _β_from_α_circular(

--- a/src/mappings/analytic/plummer.jl
+++ b/src/mappings/analytic/plummer.jl
@@ -204,5 +204,5 @@ function _β_from_α_circular(
     # α = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2))
     # use bisection on this function directly
     rootequation(β::Float64) = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2)) - α
-    return _bisection(rootequation, 1/2, 1)
+    return _bisection(rootequation, 1/2, 1.0)
 end

--- a/src/mappings/analytic/plummer.jl
+++ b/src/mappings/analytic/plummer.jl
@@ -169,7 +169,12 @@ function _Ω1circular(
 )::Float64
     x = r / radial_scale(model) # dimensionless radius
     s = _s_from_r(r, model, params)
-    return frequency_scale(model) * sqrt(4 + x^2) / (2 * s^(5/2))
+
+    if (r == Inf) # Necessary to avoid a NaN at r=Inf
+        return 0.0
+    else
+        return frequency_scale(model) * sqrt(4 + x^2) / (2 * s^(5/2))
+    end
 end
 
 function _Ω2circular(

--- a/src/mappings/analytic/toomre.jl
+++ b/src/mappings/analytic/toomre.jl
@@ -170,7 +170,12 @@ function _Ω1circular(
 )::Float64
     x = r / radial_scale(model) # dimensionless radius
     s = _s_from_r(r, model, params)
-    return frequency_scale(model) * sqrt(4 + x^2) / (2 * s^(5/2))
+    
+    if (r == Inf) # Necessary to avoid a NaN at r=Inf
+        return 0.0
+    else
+        return frequency_scale(model) * sqrt(4 + x^2) / (2 * s^(5/2))
+    end
 end
 
 function _Ω2circular(

--- a/src/mappings/analytic/toomre.jl
+++ b/src/mappings/analytic/toomre.jl
@@ -205,5 +205,5 @@ function _β_from_α_circular(
     # α = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2))
     # use bisection on this function directly
     rootequation(β::Float64) = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2)) - α
-    return _bisection(rootequation, 1/2, 1)
+    return _bisection(rootequation, 1/2, 1.0)
 end

--- a/src/mappings/analytic/toomre.jl
+++ b/src/mappings/analytic/toomre.jl
@@ -1,0 +1,204 @@
+#
+#
+# This follows K.Tep implementation in CARP
+# The Toomre potential in the disk plane is the same as the Plummer potential
+#
+#
+
+########################################################################
+#
+# (a,e) ↔ (E,L) mappings
+#
+########################################################################
+"""
+for Toomre analytical version, see equation @ADDREFERENCE
+"""
+function EL_from_ae(
+    a::Float64,
+    e::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)
+    rp, ra = rpra_from_ae(a, e)
+    sp, sa = _spsa_from_rpra(rp, ra, model, params) # extremal anomalies on the orbit
+    Ẽ = 1 / sp - (sa^2 - 1) / (sa * sp * (sa + sp)) # dimensionless energy
+    L̃ = sqrt(2 * (sp^2 - 1) * (sa^2 - 1) / (sa * sp * (sa + sp))) # dimensionless momentum
+    return energy_scale(model) * Ẽ, momentum_scale(model) * L̃ 
+end
+
+"""    
+for Toomre analytical version, can be found by 1D-bisection instead of 
+2D inversion scheme.
+"""
+function ae_from_EL(
+    E::Float64,
+    L::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)
+    sp, sa = _spsa_from_EL(E, L, model, params)
+    rp, ra = _rpra_from_spsa(sp, sa, model, params)
+    return ae_from_rpra(rp, ra)
+end
+
+function _spsa_from_EL(
+    E::Float64,
+    L::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)
+    Ẽ = E / energy_scale(model) # dimensionless energy
+    L̃ = L / momentum_scale(model) # dimensionless angular momentum
+
+    # Edge cases
+    # @ADDREFERENCE for this cryptic formula to find root from
+    rootequation = (s -> Ẽ * s^3 - s^2 + ((L̃^2) / 2 - Ẽ) * s + 1)
+    if Ẽ <= 0 # unbounded orbits
+        if L̃ == 0 # radial orbits
+            return 1.0, Inf
+        else # arbitrary orbit
+            sp = _bisection(rootequation, 1.0, 2 / (L̃^2 - 2Ẽ))
+            return sp, Inf
+        end
+    elseif L̃ == 0 # radial orbit
+        return 1.0, 1 / Ẽ
+    end
+
+    #  Generic case: bounded orbits
+    # 1 < sp < sc and sc < sa < E0/E with sc the circular anomaly
+    # @ADDREFERENCE for this cryptic formulae
+    # Anomaly of the circular orbit of energy E
+    x1, x2, x3 = 1 / (6Ẽ), (1 + 54Ẽ^2) / (216Ẽ^3), sqrt(1 + 1 / (27Ẽ^2)) / (4Ẽ)
+    scircular = x1 + ∛(x2 + x3) + ∛(x2 - x3)
+    η̃ = (scircular^2 - 1) * (1 / scircular - Ẽ)
+    L̃circular = Ẽ == 1 ? 0.0 : sqrt(abs(2η̃))
+    if L̃ >= L̃circular # circular orbits
+        # @IMPROVE: inequality to take care of small Float errors, not ideal
+        # should find some proper cutoff for quasi circular orbits
+        return scircular, scircular
+    end
+
+    sp = _bisection(rootequation, 1.0, scircular)
+    # upper bound should be E0/E + 1 in order to get a proper bracket
+    sa = _bisection(rootequation, scircular, 1 + 1/Ẽ)
+    return sp, sa
+end
+
+########################################################################
+#
+# (a,e) ↔ frequencies mappings: integrands
+#
+########################################################################
+"""
+the analytic expression for Theta for the Plummer profile are given in 
+Tep et al. 2022 eq. (F9). It has the major advantage of 
+always being well-posed for -1<u<1
+
+@QUESTION: is `w` hard-coded as Hénon's anomaly here ?
+"""
+function _Θ(
+    w::Float64,
+    a::Float64,
+    e::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)
+    rp, ra = rpra_from_ae(a, e) # peri and apocentre
+    sp, sa = _spsa_from_rpra(rp, ra, model, params) # extremal anomalies
+    
+    # Analytical expression of (dr/dw)(1/vr), that is always well-posed
+    # see equation (F9) in Tep et al. (2022).
+    tep_a = sp * (w + 2) * (w - 1)^2 - sa * (w - 2) * (w + 1)^2
+    tep_b = sp * (w^3 - 3w + 6) - sa * (w^3 - 3w - 6)
+
+    return (
+        3 
+        * sqrt(sa * sp * (sa + sp))
+        * tep_a^(3/2)
+        / sqrt(sa * sp * tep_a + tep_b)
+        / sqrt(4 - w^2)
+        / (2 * sqrt(2) * frequency_scale(model))
+    )
+end
+
+# @IMPROVE:  we do not cure the β computation for near radial orbits using logarithmic 
+# sampling near pericentre as in K.Tep's CARP algorithm. For this case the tolerance
+# on eccentricity should be increased, at least, to 0.1.
+
+########################################################################
+#
+# (a,e) ↦ actions mapping
+#
+########################################################################
+# With this anomaly the usual radial action computation is not a good idea.
+# Rather use the cured Θ definition than dr/dw
+function _radial_action_from_ae(
+    a::Float64,
+    e::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)::Float64
+    # Edge cases
+    if a == 0 || e == 0
+        return 0.0
+    end
+    # Handling (a,e)-domain edges through interpolation
+    # IMPORTANT : has to be before the generic computation
+    fun(atmp::Float64, etmp::Float64) = _radial_action_from_ae(atmp, etmp, model, params)
+    res = _interpolate_edges_ae(fun, a, e, params)
+    if !isnothing(res)
+        return res
+    end
+    # Generic computations
+    function action_integrand(w::Float64)::Float64
+        drdw_over_vrad = _Θ(w, a, e, model, params)
+        vrad = radial_velocity(w, a, e, model, params)
+        return drdw_over_vrad * vrad^2
+    end
+    return (1 / pi) * _integrate_simpson(action_integrand, params.NINT)
+end
+
+########################################################################
+#
+# (a, e) ↔ frequencies mappings: circular
+#
+########################################################################
+function _Ω1circular(
+    r::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)::Float64
+    x = r / radial_scale(model) # dimensionless radius
+    s = _s_from_r(r, model, params)
+    return frequency_scale(model) * sqrt(4 + x^2) / (2 * s^(5/2))
+end
+
+function _Ω2circular(
+    r::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)::Float64
+    s = _s_from_r(r, model)
+    return frequency_scale(model) / (2 * s^(3/2))
+end
+
+function _βcircular(
+    r::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)::Float64
+    x = r / radial_scale(model) 
+    return sqrt(1 - 3 / (4 + x^2))
+end
+
+function _β_from_α_circular(
+    α::Float64,
+    model::SemiAnalyticToomre,
+    params::OrbitalParameters=OrbitalParameters()
+)::Float64
+    # Circular orbits: 
+    # α = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2))
+    # use bisection on this function directly
+    rootequation(β::Float64) = (1 - β^2)^(3/4) / (2 * 3^(3/4) * β^(5/2)) - α
+    return _bisection(rootequation, 1/2, 1)
+end

--- a/src/mappings/analytic/toomre.jl
+++ b/src/mappings/analytic/toomre.jl
@@ -22,7 +22,7 @@ function EL_from_ae(
     rp, ra = rpra_from_ae(a, e)
     sp, sa = _spsa_from_rpra(rp, ra, model, params) # extremal anomalies on the orbit
     Ẽ = 1 / sp - (sa^2 - 1) / (sa * sp * (sa + sp)) # dimensionless energy
-    L̃ = sqrt(2 * (sp^2 - 1) * (sa^2 - 1) / (sa * sp * (sa + sp))) # dimensionless momentum
+    L̃ = sqrt(abs(2 * (sp^2 - 1) * (sa^2 - 1) / (sa * sp * (sa + sp)))) # dimensionless momentum
     return energy_scale(model) * Ẽ, momentum_scale(model) * L̃ 
 end
 
@@ -170,7 +170,7 @@ function _Ω1circular(
 )::Float64
     x = r / radial_scale(model) # dimensionless radius
     s = _s_from_r(r, model, params)
-    
+
     if (r == Inf) # Necessary to avoid a NaN at r=Inf
         return 0.0
     else
@@ -193,7 +193,7 @@ function _βcircular(
     params::OrbitalParameters=OrbitalParameters()
 )::Float64
     x = r / radial_scale(model) 
-    return sqrt(1 - 3 / (4 + x^2))
+    return sqrt(abs(1 - 3 / (4 + x^2)))
 end
 
 function _β_from_α_circular(

--- a/src/potentials/potentials.jl
+++ b/src/potentials/potentials.jl
@@ -109,6 +109,7 @@ include("isochrone.jl")
 include("plummer.jl")
 include("hernquist.jl")
 include("mestelzang.jl")
+include("toomre.jl")
 
 # three integral potentials
 include("kuzminkutuzov.jl")

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -11,19 +11,44 @@
 """
 Toomre potential structure
 """
-struct ToomrePotential <: TwoIntegralCentralCorePotential
+abstract type ToomrePotential <: TwoIntegralCentralCorePotential end
+struct NumericalToomre <: ToomrePotential
+    G::Float64      # Gravitational constant
+    M::Float64      # Total mass
+    bc::Float64     # Characteristic radius
+end
+struct SemiAnalyticToomre <: ToomrePotential
     G::Float64      # Gravitational constant
     M::Float64      # Total mass
     bc::Float64     # Characteristic radius
 end
 
 """
-    ToomrePotential([, R0, V0])
+    NumericalToomre([, G, M, bc])
 
-Create a Toomre potential structure. 
+This Toomre model will use the default numerical computations
 """
-function ToomrePotential(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
-    return ToomrePotential(G,M,bc)
+function NumericalToomre(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
+    # Check for positive mass and radius
+    if M<0; throw(DomainError(M, "Negative mass")); end
+    if bc≤0; throw(DomainError(bc, "Negative characteristic radius")); end
+
+    return NumericalToomre(G,M,bc)
+end
+
+"""
+    SemiAnalyticToomre([, G, M, bc])
+
+This Toomre model will use the semi-analytic mappings with an anomaly 
+such that the frequency integrand [`Θ(u, a, e, ...)`](@ref) is known.
+The frequencies are still computed through numerical integration of this integrand.
+"""
+function SemiAnalyticToomre(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
+    # Check for positive mass and radius
+    if M<0; throw(DomainError(M, "Negative mass")); end
+    if bc≤0; throw(DomainError(bc, "Negative characteristic radius")); end
+
+    return SemiAnalyticToomre(G,M,bc)
 end
 
 #####################################

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -11,7 +11,7 @@
 """
 Toomre potential structure
 """
-struct ToomrePotential <:  TwoIntegralCentralCorePotential  end
+struct ToomrePotential <: TwoIntegralCentralCorePotential
     G::Float64      # Gravitational constant
     M::Float64      # Total mass
     bc::Float64     # Characteristic radius

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -11,8 +11,7 @@
 """
 Toomre potential structure
 """
-abstract type ToomrePotential <:  TwoIntegralCentralCorePotential  end
-struct AnalyticToomre <: ToomrePotential
+struct ToomrePotential <:  TwoIntegralCentralCorePotential  end
     G::Float64      # Gravitational constant
     M::Float64      # Total mass
     bc::Float64     # Characteristic radius
@@ -23,8 +22,8 @@ end
 
 Create a Toomre potential structure. 
 """
-function AnalyticToomre(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
-    return AnalyticToomre(G,M,bc)
+function ToomrePotential(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
+    return ToomrePotential(G,M,bc)
 end
 
 #####################################

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -69,7 +69,7 @@ end
 # Scales for Toomre
 #####################################
 function frequency_scale(model::ToomrePotential)
-    return sqrt(model.G*model.M/(model.bc^3))
+    return 2*sqrt(model.G*model.M/(model.bc^3))
 end
 
 function radial_scale(model::ToomrePotential)

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -11,7 +11,8 @@
 """
 Toomre potential structure
 """
-struct ToomrePotential <: TwoIntegralCentralCorePotential 
+abstract type ToomrePotential <:  TwoIntegralCentralCorePotential  end
+struct AnalyticToomre <: ToomrePotential
     G::Float64      # Gravitational constant
     M::Float64      # Total mass
     bc::Float64     # Characteristic radius
@@ -22,8 +23,8 @@ end
 
 Create a Toomre potential structure. 
 """
-function ToomrePotential(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
-    return ToomrePotential(G,M,bc)
+function AnalyticToomre(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
+    return AnalyticToomre(G,M,bc)
 end
 
 #####################################

--- a/src/potentials/toomre.jl
+++ b/src/potentials/toomre.jl
@@ -1,0 +1,85 @@
+
+#####################################
+#
+# Classic Toomre potential
+#
+#####################################
+
+#####################################
+# Toomre structure
+#####################################
+"""
+Toomre potential structure
+"""
+struct ToomrePotential <: TwoIntegralCentralCorePotential 
+    G::Float64      # Gravitational constant
+    M::Float64      # Total mass
+    bc::Float64     # Characteristic radius
+end
+
+"""
+    ToomrePotential([, R0, V0])
+
+Create a Toomre potential structure. 
+"""
+function ToomrePotential(;G::Float64=1.,M::Float64=1.,bc::Float64=1.)
+    return ToomrePotential(G,M,bc)
+end
+
+#####################################
+# Potential methods for Toomre
+#####################################
+function ψ(r::Float64,model::ToomrePotential)
+    # Check for positive radius
+    if r<0; throw(DomainError(r, "Negative radius")); end
+    
+    x = r/model.bc
+    scale = model.G * model.M / model.bc
+    return -scale / sqrt(1.0 + x^2)
+end
+
+function dψ(r::Float64,model::ToomrePotential)
+    # Check for positive radius
+    if r<0; throw(DomainError(r, "Negative radius")); end
+
+    x = r/model.bc
+    scale = model.G * model.M / (model.bc)^2
+    # Stable version at infinity (not stable in 0.)
+    if x > 1.e5
+        return scale / (x^2 * (sqrt(1.0+x^(-2)))^3)
+    end
+    return scale * x / (sqrt(1.0+x^2))^3
+end
+
+function d2ψ(r::Float64,model::ToomrePotential)
+    # Check for positive radius
+    if r<0; throw(DomainError(r, "Negative radius")); end
+
+    x = r/model.bc
+    scale = model.G * model.M / (model.bc)^3
+    # Stable version at infinity (not stable in 0.)
+    if x > 1.e5
+        return scale * ( 1.0 / (sqrt(1.0 + x^2))^3 
+                        - 3.0 / (x^3 * (sqrt(1.0 + x^(-2)))^5))
+    end
+    return scale * (1.0 - 2.0*(x^2)) / (sqrt(1.0 + x^2))^5
+end
+
+#####################################
+# Scales for Toomre
+#####################################
+function frequency_scale(model::ToomrePotential)
+    return sqrt(model.G*model.M/(model.bc^3))
+end
+
+function radial_scale(model::ToomrePotential)
+    return model.bc
+end
+
+function energy_scale(model::ToomrePotential)
+    return -model.G*model.M/model.bc
+end
+
+function momentum_scale(model::ToomrePotential)
+    return sqrt(model.G*model.M*model.bc)
+end

--- a/test/test_mappings.jl
+++ b/test/test_mappings.jl
@@ -316,4 +316,80 @@
             end
         end
     end
+    #################################
+    # Toomre Semi-Analytical vs Numerical
+    # Same as Plummer in practice
+    #################################
+    @testset "Toomre" begin
+        # Compare analytical to numerical results in the isochrone
+        anapot = SemiAnalyticToomre()
+        numpot = NumericalToomre()
+        # For semi-analytical computations (K.Tep's CARP-like)
+        # use an increased tolerance on eccentricity to prevent wrong computations of
+        # the frequency ratio β close to radial orbits.
+        anaparams = OrbitalParameters(rc=radial_scale(anapot), TOLECC=0.1)
+        numparams = OrbitalParameters(rc=radial_scale(numpot))
+        @testset "forward" begin
+            for (mapping, fun) in [
+                ("EL", EL_from_ae),
+                ("actions", actions_from_ae),
+                ("frequencies", frequencies_from_ae)
+            ]
+                @testset "$mapping" begin
+                    # Defining the mappings to compare
+                    ana(a, e) = fun(a, e, anapot, anaparams)
+                    num(a, e) = fun(a, e, numpot, numparams)
+                    @testset "regular" begin
+                        tol =  1.e-3
+                        compare_mappings(ana, num, aregular, eregular; atol=tol, rtol=tol)
+                    end
+                    @testset "borders" begin
+                        tol =  1.e-3
+                        # compare_mappings(ana, num, aborder, eregular; atol=tol, rtol=tol)
+                        # compare_mappings(ana, num, aregular, eborders; atol=tol, rtol=tol)
+                        # compare_mappings(ana, num, aborder, eborders; atol=tol, rtol=tol)
+                    end
+                end
+            end
+        end
+        @testset "backward" begin
+            for (version, pot, params) in [
+                ("analytic", anapot, anaparams), 
+                ("numerical", numpot, numparams)
+            ]
+                @testset "$version" begin
+                    for (mapping, forwardfun, backwardfun) in [
+                        ("EL", EL_from_ae, ae_from_EL),
+                        ("actions", actions_from_ae, ae_from_actions),
+                        ("frequencies", frequencies_from_ae, ae_from_frequencies)
+                    ]
+                        @testset "$mapping" begin
+                            # Defining the mappings to compare
+                            forward(a, e) = forwardfun(a, e, pot, params)
+                            backward(E, L) = backwardfun(E, L, pot, params)
+                            @testset "regular" begin
+                                tol =  1.e-3
+                                test_backwardmapping(
+                                    forward, backward, aregular, eregular, tol
+                                )
+                            end
+                            @testset "borders" begin
+                                tol =  1.e-3
+                                # test_backwardmapping(
+                                #     forward, backward, aregular, eborders, tol
+                                # )
+                                # @IMPROVE: for now still issues in the centre !
+                                # test_backwardmapping(
+                                #     forward, backward, aborder, eregular, tol
+                                # )
+                                # test_backwardmapping(
+                                #     forward, backward, aborder, eborders, tol
+                                # )
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 end

--- a/test/test_potentials.jl
+++ b/test/test_potentials.jl
@@ -156,29 +156,27 @@
         end
     end
     @testset "toomre" begin
-        @testset "analytic" begin
-            # Toomre potential with default values
-            # supposedly G=1, M=1, bc=1
-            model = AnalyticToomre()
-            @test_throws DomainError ψ(-1.,model)
-            @test ψ(0.,model) ≈ -1.
-            @test ψ(1.,model) ≈ -1/sqrt(2)
-            @test ψ(Inf,model) == 0.
-            # Check first derivative
-            @test_throws DomainError dψ(-1.,model)
-            @test dψ(0.,model) == 0.
-            @test dψ(1.,model) ≈ sqrt(2)/4
-            @test dψ(Inf,model) == 0.
-            # Check second derivative
-            @test_throws DomainError d2ψ(-1.,model)
-            @test d2ψ(0.,model) == 1.
-            @test d2ψ(1.,model) ≈ -sqrt(2)/8
-            @test d2ψ(Inf,model) == 0.
-            # Check scale functions
-            @test frequency_scale(model) ≈ 1.
-            @test energy_scale(model) ≈ -1.
-            @test momentum_scale(model) ≈ 1.
-            @test radial_scale(model) ≈ 1.
-        end
+        # Toomre potential with default values
+        # supposedly G=1, M=1, bc=1
+        model = ToomrePotential()
+        @test_throws DomainError ψ(-1.,model)
+        @test ψ(0.,model) ≈ -1.
+        @test ψ(1.,model) ≈ -1/sqrt(2)
+        @test ψ(Inf,model) == 0.
+        # Check first derivative
+        @test_throws DomainError dψ(-1.,model)
+        @test dψ(0.,model) == 0.
+        @test dψ(1.,model) ≈ sqrt(2)/4
+        @test dψ(Inf,model) == 0.
+        # Check second derivative
+        @test_throws DomainError d2ψ(-1.,model)
+        @test d2ψ(0.,model) == 1.
+        @test d2ψ(1.,model) ≈ -sqrt(2)/8
+        @test d2ψ(Inf,model) == 0.
+        # Check scale functions
+        @test frequency_scale(model) ≈ 1.
+        @test energy_scale(model) ≈ -1.
+        @test momentum_scale(model) ≈ 1.
+        @test radial_scale(model) ≈ 1.
     end
 end

--- a/test/test_potentials.jl
+++ b/test/test_potentials.jl
@@ -155,4 +155,30 @@
             @test radial_scale(model) ≈ 1.
         end
     end
+    @testset "toomre" begin
+        @testset "analytic" begin
+            # Toomre potential with default values
+            # supposedly G=1, M=1, bc=1
+            model = AnalyticToomre()
+            @test_throws DomainError ψ(-1.,model)
+            @test ψ(0.,model) ≈ -1.
+            @test ψ(1.,model) ≈ -1/sqrt(2)
+            @test ψ(Inf,model) == 0.
+            # Check first derivative
+            @test_throws DomainError dψ(-1.,model)
+            @test dψ(0.,model) == 0.
+            @test dψ(1.,model) ≈ sqrt(2)/4
+            @test dψ(Inf,model) == 0.
+            # Check second derivative
+            @test_throws DomainError d2ψ(-1.,model)
+            @test d2ψ(0.,model) == 1.
+            @test d2ψ(1.,model) ≈ -sqrt(2)/8
+            @test d2ψ(Inf,model) == 0.
+            # Check scale functions
+            @test frequency_scale(model) ≈ 1.
+            @test energy_scale(model) ≈ -1.
+            @test momentum_scale(model) ≈ 1.
+            @test radial_scale(model) ≈ 1.
+        end
+    end
 end

--- a/test/test_potentials.jl
+++ b/test/test_potentials.jl
@@ -156,27 +156,43 @@
         end
     end
     @testset "toomre" begin
-        # Toomre potential with default values
-        # supposedly G=1, M=1, bc=1
-        model = ToomrePotential()
-        @test_throws DomainError ψ(-1.,model)
-        @test ψ(0.,model) ≈ -1.
-        @test ψ(1.,model) ≈ -1/sqrt(2)
-        @test ψ(Inf,model) == 0.
-        # Check first derivative
-        @test_throws DomainError dψ(-1.,model)
-        @test dψ(0.,model) == 0.
-        @test dψ(1.,model) ≈ sqrt(2)/4
-        @test dψ(Inf,model) == 0.
-        # Check second derivative
-        @test_throws DomainError d2ψ(-1.,model)
-        @test d2ψ(0.,model) == 1.
-        @test d2ψ(1.,model) ≈ -sqrt(2)/8
-        @test d2ψ(Inf,model) == 0.
-        # Check scale functions
-        @test frequency_scale(model) ≈ 1.
-        @test energy_scale(model) ≈ -1.
-        @test momentum_scale(model) ≈ 1.
-        @test radial_scale(model) ≈ 1.
+        @testset "numerical" begin
+            # Wrong model characteristic values
+            @test_throws DomainError NumericalToomre(M=-1.)
+            @test_throws DomainError NumericalToomre(bc=0.)
+            # Toomre potential with default values
+            # supposedly G=1, M=1, bc=1
+            model = NumericalToomre()
+            @test_throws DomainError ψ(-1.,model)
+            @test ψ(0.,model) ≈ -1.
+            @test ψ(1.,model) ≈ -1/sqrt(2)
+            @test ψ(Inf,model) == 0.
+            # Check first derivative
+            @test_throws DomainError dψ(-1.,model)
+            @test dψ(0.,model) == 0.
+            @test dψ(1.,model) ≈ sqrt(2)/4
+            @test dψ(Inf,model) == 0.
+            # Check second derivative
+            @test_throws DomainError d2ψ(-1.,model)
+            @test d2ψ(0.,model) == 1.
+            @test d2ψ(1.,model) ≈ -sqrt(2)/8
+            @test d2ψ(Inf,model) == 0.
+            # Check scale functions
+            @test frequency_scale(model) ≈ 2.
+            @test energy_scale(model) ≈ -1.
+            @test momentum_scale(model) ≈ 1.
+            @test radial_scale(model) ≈ 1.
+        end
+        @testset "semi-analytic" begin
+            # Wrong model characteristic values
+            @test_throws DomainError SemiAnalyticToomre(M=-1.)
+            @test_throws DomainError SemiAnalyticToomre(bc=0.)
+            # Isochrone potential
+            @test_nowarn SemiAnalyticToomre()
+            # Do not test the potential and derivatives as they go throught the exact 
+            # same functions as the analytical version.
+        end
     end
+
+
 end


### PR DESCRIPTION
This branch implements the Toomre potential for thin disks, which is basically a copy pasting of the Plummer disk.
It also includes implementing both numerical and semi-analytical Toomre potentials, as well as the associated tests.

This branch also fixes a bug with the SemiAnalyticPlummer potential, for which we had alpha_circular(Inf)=NaN due to a 0/0 operation. The in turn made it impossible to use for LinearResponse.jl scripts. 

This branch also introduces additional safe handling of sqrt() by introducing an abs() whenever necessary. This is necessary because in some cases, the analytic potentials would create negative values of order 1e-15. 

/!\ /!\ For now, I don't get the same unstable modes for the Analytic model and the Numerical model for Plummer ?